### PR TITLE
Make code compatible with PHP 7.4 as declared in composer.json

### DIFF
--- a/src/Moodle/CoreComponentBridge.php
+++ b/src/Moodle/CoreComponentBridge.php
@@ -348,9 +348,10 @@ final class CoreComponentBridge
      *
      * This is specifically for use with the getStaticPropertyValue() method of ReflectionClass.
      *
+     * @param mixed $map
      * @return array<string, string>
      */
-    private static function toStringMap(mixed $map): array
+    private static function toStringMap($map): array
     {
         if (!is_array($map)) {
             throw new RuntimeException('Map is not an array');

--- a/src/MoodleRootManager.php
+++ b/src/MoodleRootManager.php
@@ -9,8 +9,14 @@ use ReflectionException;
 
 class MoodleRootManager
 {
-    public function __construct(private string $moodleRoot, private bool $addCommonIncludes)
+    private string $moodleRoot;
+
+    private bool $addCommonIncludes;
+
+    public function __construct(string $moodleRoot, bool $addCommonIncludes)
     {
+        $this->moodleRoot = $moodleRoot;
+        $this->addCommonIncludes = $addCommonIncludes;
         if (!is_dir($this->moodleRoot) || !file_exists($this->moodleRoot . '/lib/components.json')) {
             throw new InvalidArgumentException("Moodle root does not exist or is not a valid Moodle codebase");
         }


### PR DESCRIPTION
composer.json mirrors PHPStan's own PHP constraint (`^7.4|^8.0`), but the code used PHP 8.0-only syntax: constructor property promotion in `MoodleRootManager` and a `mixed` parameter type in `CoreComponentBridge::toStringMap()`, both of which fail to parse on PHP 7.4.

This replaces the promoted constructor properties with explicit declarations and the `mixed` native type with a `@param mixed` docblock, keeping PHPStan level 8 clean.

Note: `rector.php` uses `withPhpSets()`, which derives the target version from composer.json, so Rector will not reintroduce PHP 8.0 syntax.