### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint-lowest-php:
+    name: Lint on PHP 7.4
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+
+      # The dev dependencies require PHP 8.2+, so the test suite cannot run on
+      # the minimum supported version. Checking that the shipped code parses on
+      # PHP 7.4 catches accidental use of newer syntax.
+      - name: Check syntax against minimum supported PHP
+        run: find src bootstrap.php -name '*.php' -print0 | xargs -0 -n1 -P4 php -l
+
+  tests:
+    name: Tests on PHP ${{ matrix.php }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.2', '8.3', '8.4', '8.5']
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - uses: ramsey/composer-install@v3
+
+      - name: Run tests
+        run: composer test
+
+      - name: Run PHPStan
+        run: composer phpstan


### PR DESCRIPTION
Adds a CI workflow with two jobs:

- **Lint on PHP 7.4** — runs `php -l` over `src/` and `bootstrap.php` to catch syntax above the minimum supported PHP version. The test suite can't cover this because the dev dependencies (phpunit 11) require PHP 8.2+. This check would have caught the constructor-promotion issue fixed in #17.
- **Tests on PHP 8.2–8.5** — `composer install` (cached via ramsey/composer-install), then the test suite and PHPStan level 8 via the existing composer scripts.

Triggers on pushes to main and on all pull requests.