### PR TITLE
Support relative paths for the moodle.rootDirectory parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ parameters:
 
 ```
 
-The rootDirectory parameter *must* be an absolute path. Also, `composer install` must have been run in the Moodle root directory to create the vendor directory.
+The rootDirectory parameter may be an absolute path, or a path relative to the config file it is written in (in the same way as PHPStan's own path parameters such as `paths` and `scanDirectories`). Also, `composer install` must have been run in the Moodle root directory to create the vendor directory.
 
 ### Common includes
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "phpstan-extension",
   "require": {
     "php": "^7.4|^8.0",
-    "phpstan/phpstan": "^2.0"
+    "phpstan/phpstan": "^2.1.18"
   },
   "require-dev": {
     "rector/rector": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a887e1ec0b56f2760b5db0a8df9383c7",
+    "content-hash": "69fdc58fdb681972242cb2491e1437b1",
     "packages": [
         {
             "name": "phpstan/phpstan",

--- a/extension.neon
+++ b/extension.neon
@@ -58,3 +58,9 @@ parametersSchema:
 		rootDirectory: string(),
 		addCommonIncludes: bool()
 	])
+
+# Resolve a relative moodle.rootDirectory against the directory of the
+# config file it is written in, like PHPStan's own path parameters.
+# Requires PHPStan 2.1.18+.
+expandRelativePaths:
+	- '[parameters][moodle][rootDirectory]'

--- a/tests/Config/RelativeRootDirectoryTest.php
+++ b/tests/Config/RelativeRootDirectoryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PhpstanMoodle\Test\Config;
+
+use PHPStan\Testing\PHPStanTestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
+
+/**
+ * Tests that a relative moodle.rootDirectory in a config file is resolved
+ * against the directory of that config file, via the expandRelativePaths
+ * declaration in extension.neon.
+ */
+#[CoversNothing]
+class RelativeRootDirectoryTest extends PHPStanTestCase
+{
+
+    public function testRelativeRootDirectoryIsResolvedAgainstConfigFile(): void
+    {
+        $container = self::getContainer();
+
+        $moodle = $container->getParameter('moodle');
+
+        $this->assertSame(
+            dirname(__DIR__) . '/data',
+            $moodle['rootDirectory']
+        );
+    }
+
+    public static function getAdditionalConfigFiles(): array
+    {
+        return [
+            __DIR__ . '/data/relative_root.neon'
+        ];
+    }
+
+}

--- a/tests/Config/data/relative_root.neon
+++ b/tests/Config/data/relative_root.neon
@@ -1,0 +1,10 @@
+includes:
+    - ../../../extension.neon
+
+parameters:
+    # Prevent bootstrap.php from running, as it would try to initialise
+    # a real Moodle installation.
+    bootstrapFiles!: []
+    moodle:
+        # Resolves to the tests/data directory of this project.
+        rootDirectory: ../../data


### PR DESCRIPTION
Previously `moodle.rootDirectory` had to be an absolute path, because PHPStan only applied its config-file-relative path resolution to a fixed list of its own parameters and extensions had no way to opt in.

PHPStan 2.1.18 introduced the `expandRelativePaths` config section ([phpstan-src@72c2a8d](https://github.com/phpstan/phpstan-src/commit/72c2a8da27960198a00c40075649d71a6a4fdebb)), which lets extensions register their own parameters for the same treatment. This PR declares `[parameters][moodle][rootDirectory]` there, so a relative value is now absolutized against the directory of the config file it is written in — exactly like the built-in `paths` and `scanDirectories` parameters.

Backwards compatibility:

- Absolute paths pass through unchanged, so existing configurations are unaffected.
- Values containing `%` (e.g. `%currentWorkingDirectory%/moodle`) are skipped by the expansion, so parameter-based setups keep working.
- The phpstan requirement is bumped from `^2.0` to `^2.1.18`, because older versions fail on the unknown `expandRelativePaths` section. The ceiling is unchanged (still <3.0); the lock file resolves to phpstan 2.2.2.

Includes a test that builds a real PHPStan container from a config including the actual `extension.neon` with `rootDirectory: ../../data`, and asserts the parameter resolves to the absolute `tests/data` path. The test config clears `bootstrapFiles!` so container creation doesn't attempt to initialise a real Moodle.

The README note requiring absolute paths has been updated accordingly.