### PR TITLE
Rename type extension classes to match what they implement

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -39,17 +39,17 @@ services:
 			addCommonIncludes: %moodle.addCommonIncludes%
 
 	-
-		class: PhpstanMoodle\Type\GetAuthPluginTypeSpecifyingExtension
+		class: PhpstanMoodle\Type\GetAuthPluginDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
-		class: PhpstanMoodle\Type\EnrolGetPluginTypeSpecifyingExtension
+		class: PhpstanMoodle\Type\EnrolGetPluginDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
-		class: PhpstanMoodle\Type\GetPluginGeneratorTypeSpecifyingExtension
+		class: PhpstanMoodle\Type\GetPluginGeneratorDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension
 

--- a/src/Type/EnrolGetPluginDynamicReturnTypeExtension.php
+++ b/src/Type/EnrolGetPluginDynamicReturnTypeExtension.php
@@ -7,15 +7,17 @@ use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
+use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use PHPStan\Type\UnionType;
 
-class GetAuthPluginTypeSpecifyingExtension implements DynamicFunctionReturnTypeExtension
+class EnrolGetPluginDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 
     public function isFunctionSupported(FunctionReflection $functionReflection): bool
     {
-        return $functionReflection->getName() === 'get_auth_plugin';
+        return $functionReflection->getName() === 'enrol_get_plugin';
     }
 
     public function getTypeFromFunctionCall(
@@ -31,7 +33,7 @@ class GetAuthPluginTypeSpecifyingExtension implements DynamicFunctionReturnTypeE
             return null;
         }
 
-        // The function throws an exception if the plugin type is not found so it is never null.
-        return new ObjectType('\auth_plugin_' . $arg1->value);
+        // The function returns null if the plugin is not found.
+        return new UnionType([new NullType(), new ObjectType('\enrol_' . $arg1->value . '_plugin')]);
     }
 }

--- a/src/Type/GetAuthPluginDynamicReturnTypeExtension.php
+++ b/src/Type/GetAuthPluginDynamicReturnTypeExtension.php
@@ -7,17 +7,15 @@ use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
-use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
-use PHPStan\Type\UnionType;
 
-class EnrolGetPluginTypeSpecifyingExtension implements DynamicFunctionReturnTypeExtension
+class GetAuthPluginDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
 
     public function isFunctionSupported(FunctionReflection $functionReflection): bool
     {
-        return $functionReflection->getName() === 'enrol_get_plugin';
+        return $functionReflection->getName() === 'get_auth_plugin';
     }
 
     public function getTypeFromFunctionCall(
@@ -33,7 +31,7 @@ class EnrolGetPluginTypeSpecifyingExtension implements DynamicFunctionReturnType
             return null;
         }
 
-        // The function returns null if the plugin is not found.
-        return new UnionType([new NullType(), new ObjectType('\enrol_' . $arg1->value . '_plugin')]);
+        // The function throws an exception if the plugin type is not found so it is never null.
+        return new ObjectType('\auth_plugin_' . $arg1->value);
     }
 }

--- a/src/Type/GetPluginGeneratorDynamicReturnTypeExtension.php
+++ b/src/Type/GetPluginGeneratorDynamicReturnTypeExtension.php
@@ -10,7 +10,7 @@ use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 
-class GetPluginGeneratorTypeSpecifyingExtension implements DynamicMethodReturnTypeExtension
+class GetPluginGeneratorDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
 
     /** @return class-string */

--- a/tests/Type/TypeExtensionsTest.php
+++ b/tests/Type/TypeExtensionsTest.php
@@ -3,15 +3,15 @@
 namespace PhpstanMoodle\Test\Type;
 
 use PHPStan\Testing\TypeInferenceTestCase;
-use PhpstanMoodle\Type\EnrolGetPluginTypeSpecifyingExtension;
-use PhpstanMoodle\Type\GetAuthPluginTypeSpecifyingExtension;
-use PhpstanMoodle\Type\GetPluginGeneratorTypeSpecifyingExtension;
+use PhpstanMoodle\Type\EnrolGetPluginDynamicReturnTypeExtension;
+use PhpstanMoodle\Type\GetAuthPluginDynamicReturnTypeExtension;
+use PhpstanMoodle\Type\GetPluginGeneratorDynamicReturnTypeExtension;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-#[CoversClass(EnrolGetPluginTypeSpecifyingExtension::class)]
-#[CoversClass(GetAuthPluginTypeSpecifyingExtension::class)]
-#[CoversClass(GetPluginGeneratorTypeSpecifyingExtension::class)]
+#[CoversClass(EnrolGetPluginDynamicReturnTypeExtension::class)]
+#[CoversClass(GetAuthPluginDynamicReturnTypeExtension::class)]
+#[CoversClass(GetPluginGeneratorDynamicReturnTypeExtension::class)]
 class TypeExtensionsTest extends TypeInferenceTestCase
 {
 

--- a/tests/Type/data/test.neon
+++ b/tests/Type/data/test.neon
@@ -5,15 +5,15 @@ parameters:
         - ../../data/lib/testing/generator/data_generator_fake.php
 services:
 	-
-		class: PhpstanMoodle\Type\GetAuthPluginTypeSpecifyingExtension
+		class: PhpstanMoodle\Type\GetAuthPluginDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 	-
-		class: PhpstanMoodle\Type\EnrolGetPluginTypeSpecifyingExtension
+		class: PhpstanMoodle\Type\EnrolGetPluginDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 
 	-
-		class: PhpstanMoodle\Type\GetPluginGeneratorTypeSpecifyingExtension
+		class: PhpstanMoodle\Type\GetPluginGeneratorDynamicReturnTypeExtension
 		tags:
 			- phpstan.broker.dynamicMethodReturnTypeExtension


### PR DESCRIPTION
The three classes were named `*TypeSpecifyingExtension`, but they implement `DynamicFunctionReturnTypeExtension` / `DynamicMethodReturnTypeExtension`. In PHPStan a type-specifying extension is a different concept (type narrowing after assertion calls), so the old names were misleading.

New names:

- `EnrolGetPluginDynamicReturnTypeExtension`
- `GetAuthPluginDynamicReturnTypeExtension`
- `GetPluginGeneratorDynamicReturnTypeExtension`

All references in `extension.neon`, the test config and the test class are updated. The classes are implementation details registered via `extension.neon`, so no user-facing impact is expected unless someone references them directly in their own config.