### PR TITLE
Resolve plugin names from the argument type, not just string literals

### DIFF
--- a/src/Type/EnrolGetPluginDynamicReturnTypeExtension.php
+++ b/src/Type/EnrolGetPluginDynamicReturnTypeExtension.php
@@ -3,14 +3,12 @@
 namespace PhpstanMoodle\Type;
 
 use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
-use PHPStan\Type\NullType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
-use PHPStan\Type\UnionType;
+use PHPStan\Type\TypeCombinator;
 
 class EnrolGetPluginDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
@@ -25,15 +23,20 @@ class EnrolGetPluginDynamicReturnTypeExtension implements DynamicFunctionReturnT
         FuncCall $functionCall,
         Scope $scope
     ): ?Type {
-        if ($functionCall->getArgs() === []) {
+        $args = $functionCall->getArgs();
+        if ($args === []) {
             return null;
         }
-        $arg1 = $functionCall->getArgs()[0]->value;
-        if (!$arg1 instanceof String_) {
+
+        $types = [];
+        foreach ($scope->getType($args[0]->value)->getConstantStrings() as $constantString) {
+            $types[] = new ObjectType('\enrol_' . $constantString->getValue() . '_plugin');
+        }
+        if ($types === []) {
             return null;
         }
 
         // The function returns null if the plugin is not found.
-        return new UnionType([new NullType(), new ObjectType('\enrol_' . $arg1->value . '_plugin')]);
+        return TypeCombinator::addNull(TypeCombinator::union(...$types));
     }
 }

--- a/src/Type/GetAuthPluginDynamicReturnTypeExtension.php
+++ b/src/Type/GetAuthPluginDynamicReturnTypeExtension.php
@@ -3,12 +3,12 @@
 namespace PhpstanMoodle\Type;
 
 use PhpParser\Node\Expr\FuncCall;
-use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\FunctionReflection;
 use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
 
 class GetAuthPluginDynamicReturnTypeExtension implements DynamicFunctionReturnTypeExtension
 {
@@ -23,15 +23,20 @@ class GetAuthPluginDynamicReturnTypeExtension implements DynamicFunctionReturnTy
         FuncCall $functionCall,
         Scope $scope
     ): ?Type {
-        if ($functionCall->getArgs() === []) {
+        $args = $functionCall->getArgs();
+        if ($args === []) {
             return null;
         }
-        $arg1 = $functionCall->getArgs()[0]->value;
-        if (!$arg1 instanceof String_) {
+
+        $types = [];
+        foreach ($scope->getType($args[0]->value)->getConstantStrings() as $constantString) {
+            $types[] = new ObjectType('\auth_plugin_' . $constantString->getValue());
+        }
+        if ($types === []) {
             return null;
         }
 
         // The function throws an exception if the plugin type is not found so it is never null.
-        return new ObjectType('\auth_plugin_' . $arg1->value);
+        return TypeCombinator::union(...$types);
     }
 }

--- a/src/Type/GetPluginGeneratorDynamicReturnTypeExtension.php
+++ b/src/Type/GetPluginGeneratorDynamicReturnTypeExtension.php
@@ -3,12 +3,12 @@
 namespace PhpstanMoodle\Type;
 
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Scalar\String_;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
 
 class GetPluginGeneratorDynamicReturnTypeExtension implements DynamicMethodReturnTypeExtension
 {
@@ -29,21 +29,26 @@ class GetPluginGeneratorDynamicReturnTypeExtension implements DynamicMethodRetur
         MethodCall $methodCall,
         Scope $scope
     ): ?Type {
-        if (count($methodCall->getArgs()) < 1) {
-            return null;
-        }
-        $arg1 = $methodCall->getArgs()[0]->value;
-        if (!$arg1 instanceof String_) {
+        $args = $methodCall->getArgs();
+        if ($args === []) {
             return null;
         }
 
-        $component = $arg1->value;
+        $types = [];
+        foreach ($scope->getType($args[0]->value)->getConstantStrings() as $constantString) {
+            $component = $constantString->getValue();
 
-        if (class_exists('core_component')) {
-            [$type, $plugin] = \core_component::normalize_component($component);
-            $component = $type . '_' . $plugin;
+            if (class_exists('core_component')) {
+                [$type, $plugin] = \core_component::normalize_component($component);
+                $component = $type . '_' . $plugin;
+            }
+
+            $types[] = new ObjectType('\\' . $component . '_generator');
+        }
+        if ($types === []) {
+            return null;
         }
 
-        return new ObjectType('\\' . $component . '_generator');
+        return TypeCombinator::union(...$types);
     }
 }

--- a/tests/Type/data/enrol_get_plugin1.php
+++ b/tests/Type/data/enrol_get_plugin1.php
@@ -7,3 +7,9 @@ use function PHPStan\Testing\assertType;
 $x = enrol_get_plugin("db");
 
 assertType('\enrol_db_plugin|null', $x);
+
+$name = 'manual';
+assertType('\enrol_manual_plugin|null', enrol_get_plugin($name));
+
+$union = rand(0, 1) === 0 ? 'manual' : 'self';
+assertType('\enrol_manual_plugin|\enrol_self_plugin|null', enrol_get_plugin($union));

--- a/tests/Type/data/get_auth_plugin1.php
+++ b/tests/Type/data/get_auth_plugin1.php
@@ -7,3 +7,9 @@ use function PHPStan\Testing\assertType;
 $x = get_auth_plugin("db");
 
 assertType('\auth_plugin_db', $x);
+
+$name = 'manual';
+assertType('\auth_plugin_manual', get_auth_plugin($name));
+
+$union = rand(0, 1) === 0 ? 'db' : 'manual';
+assertType('\auth_plugin_manual|\auth_plugin_db', get_auth_plugin($union));

--- a/tests/Type/data/get_plugin_generator1.php
+++ b/tests/Type/data/get_plugin_generator1.php
@@ -9,3 +9,6 @@ use function PHPStan\Testing\assertType;
 $t = new testing_data_generator();
 $generator1 = $t->get_plugin_generator('mod_label');
 assertType('\mod_label_generator', $generator1);
+
+$component = 'mod_quiz';
+assertType('\mod_quiz_generator', $t->get_plugin_generator($component));


### PR DESCRIPTION
**Stacked on #25** (touches the same files; GitHub will retarget this to main when #25 merges).

The extensions previously only recognised a literal string argument (`instanceof String_`), so calls like `enrol_get_plugin($name)` fell back to the generic signature type even when PHPStan knew the value of `$name`.

They now use `$scope->getType(...)->getConstantStrings()`, which handles variables, constants and any other expression with a statically known string value — including unions: an argument typed `'manual'|'self'` now returns `enrol_manual_plugin|enrol_self_plugin|null`.

Also replaces direct `UnionType` construction with `TypeCombinator`, the recommended API.

New test assertions cover the variable and union cases for all three extensions (9 type asserts in total).